### PR TITLE
Removed old PropertyChanged event from `OctoPrintClient` class

### DIFF
--- a/source/OctoPrintSharpApi/Interfaces/IPrintServerClient.cs
+++ b/source/OctoPrintSharpApi/Interfaces/IPrintServerClient.cs
@@ -1,12 +1,9 @@
 ﻿using System;
-using System.ComponentModel;
 
 namespace AndreasReitberger.API.OctoPrint.Interfaces
 {
-    public interface IPrintServerClient : INotifyPropertyChanged, IDisposable
+    public interface IPrintServerClient : IDisposable
     {
-        #region Properties
-        //public bool IsInitialized { get; set; }
-        #endregion
+
     }
 }

--- a/source/OctoPrintSharpApi/OctoPrintClient.Static.cs
+++ b/source/OctoPrintSharpApi/OctoPrintClient.Static.cs
@@ -8,7 +8,6 @@ namespace AndreasReitberger.API.OctoPrint
 {
     public partial class OctoPrintClient
     {
-
         #region Static
         public static string ConvertStackToPath(Stack<string> stack, string separator)
         {

--- a/source/OctoPrintSharpApi/OctoPrintClient.cs
+++ b/source/OctoPrintSharpApi/OctoPrintClient.cs
@@ -29,16 +29,6 @@ namespace AndreasReitberger.API.OctoPrint
     [ObservableObject]
     public partial class OctoPrintClient : IPrintServerClient
     {
-        #region INotifyPropertyChanged
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
-        {
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-        }
-
-        #endregion
-
         #region Variables
         RestClient restClient;
         HttpClient httpClient;

--- a/source/OctoPrintSharpApi/OctoPrintConnectionBuilder.cs
+++ b/source/OctoPrintSharpApi/OctoPrintConnectionBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace AndreasReitberger.API.OctoPrint
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace AndreasReitberger.API.OctoPrint
 {
     public partial class OctoPrintClient
     {

--- a/source/OctoPrintSharpApi/OctoPrintSharpApi.csproj
+++ b/source/OctoPrintSharpApi/OctoPrintSharpApi.csproj
@@ -19,9 +19,9 @@
     </PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="RCoreSharp" Version="1.0.8" />
-		<PackageReference Include="RestSharp" Version="108.0.1" />
+		<PackageReference Include="RestSharp" Version="108.0.3" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="WebSocket4Net" Version="0.15.2" />

--- a/source/OctoPrintSharpApiTest/OctoPrintSharpApiTest.csproj
+++ b/source/OctoPrintSharpApiTest/OctoPrintSharpApiTest.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.0" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This PR removes the coed snippet for the old `PropertyChanged` event, which was a leftover from a previous PR. Also the dependencies were updated to the latest version.

Fixed #9 